### PR TITLE
typo: index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ## Updating the code on early Bally/Stern Solid State Pinball Games
 
-This project consists of a library & several game implementations which add modern features and deeper rule sets to early Solid State games. The softare is hosted on a custom card that plugs into the MPU's J5 connector. The card allows the player to boot to either the original code or the new implementation with a switch mounted behind the coin door.
+This project consists of a library & several game implementations which add modern features and deeper rule sets to early Solid State games. The software is hosted on a custom card that plugs into the MPU's J5 connector. The card allows the player to boot to either the original code or the new implementation with a switch mounted behind the coin door.
 
 ### How to get it
 In order to update a machine, the operator will need to:


### PR DESCRIPTION
In the index.md file the word "software" was misspelled as "softare".
This commit resolves that issue.